### PR TITLE
refactor(trait): aggregate signature interface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub trait Crypto: Clone + Send {
     fn aggregate_signatures(
         &self,
         signatures: Vec<Signature>,
+        voters: Vec<Address>,
     ) -> Result<Signature, Box<dyn Error + Send>>;
 
     /// Verify a signature and return the recovered address.

--- a/src/state/tests/test_utils.rs
+++ b/src/state/tests/test_utils.rs
@@ -138,7 +138,8 @@ impl Crypto for BlsCrypto {
 
     fn aggregate_signatures(
         &self,
-        _msgsignatures: Vec<Signature>,
+        _signatures: Vec<Signature>,
+        _voters: Vec<Address>,
     ) -> Result<Signature, Box<dyn Error + Send>> {
         use super::gen_hash;
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -146,7 +146,8 @@ impl Crypto for BlsCrypto {
 
     fn aggregate_signatures(
         &self,
-        _msgsignatures: Vec<Signature>,
+        _signatures: Vec<Signature>,
+        _voters: Vec<Address>,
     ) -> Result<Signature, Box<dyn Error + Send>> {
         Ok(gen_hash())
     }


### PR DESCRIPTION
This PR does:
* refactor the arguments of `fn aggregate_signature()` interface