### PR TITLE
refactor(SMR): SMR event and  trigger add epoch ID and round

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ parking_lot = "0.9"
 rand_core = "0.5"
 rand_pcg = "0.2"
 rlp = "0.4"
+runtime = "0.3.0-alpha.7"
 tokio = "0.2.0-alpha.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand_core = "0.5"
 rand_pcg = "0.2"
 rlp = "0.4"
 runtime = "0.3.0-alpha.7"
+runtime-tokio = "0.3.0-alpha.6"
 tokio = "0.2.0-alpha.4"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ fn main() {
     let overlord = Overlord::new(address, OverlordEngine, OverlordCrypto);
     let handler = overlord.get_handler();
 
-    tokio::run(overlord.run().await);
+    tokio::run(overlord.run());
     handler.send_msg().unwrap();
 }
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Overlord consensus protocol.
 
 ## Intrucduction
 
-Overlord is a new consensus protocol that decouple the consensus process from the execution process. 
+Overlord is a new consensus protocol that decouple the consensus process from the execution process.
 
 Detaild intrucduction: [中文](./docs/architecture_zh.md)|English
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,36 @@
 [![Minimum rustc version](https://img.shields.io/badge/rustc-1.39+-informational.svg)](https://github.com/cryptape/overlord/blob/master/rust-toolchain)
 
 Overlord consensus protocol.
+
+## Intrucduction
+
+Overlord is a new consensus protocol that decouple the consensus process from the execution process. 
+
+Detaild intrucduction: [中文](./docs/architecture_zh.md)|English
+
+## Usage
+
+### From cargo
+
+```toml
+[dependencies]
+overlord = { git = "https://github.com/cryptape/overlord.git" }
+```
+
+### Example
+
+```rust
+use overlord::{Codec, Consensus, Context, Crypto, Overlord, OverlordHandler};
+
+impl<T, F> Consensus<T, F> for OverlordEngine {}
+
+impl Crypto for OverlordCrypto {}
+
+fn main() {
+    let overlord = Overlord::new(address, OverlordEngine, OverlordCrypto);
+    let handler = overlord.get_handler();
+
+    tokio::run(overlord.run().await);
+    handler.send_msg().unwrap();
+}
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ pub trait Codec: Clone + Debug + Send {
 }
 
 /// Trait for some crypto methods.
-pub trait Crypto: Clone + Send {
+pub trait Crypto: Send {
     /// Hash a message bytes.
     fn hash(&self, msg: Bytes) -> Hash;
 

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -11,13 +11,15 @@ use crate::types::{Address, OverlordMsg};
 use crate::{smr::SMRProvider, timer::Timer};
 use crate::{Codec, Consensus, ConsensusResult, Crypto};
 
+type Pile<T> = RwLock<Option<T>>;
+
 /// An overlord consensus instance.
 pub struct Overlord<T: Codec, S: Codec, F: Consensus<T, S>, C: Crypto> {
-    sender:    RwLock<Option<UnboundedSender<(Context, OverlordMsg<T>)>>>,
-    state_rx:  RwLock<Option<UnboundedReceiver<(Context, OverlordMsg<T>)>>>,
-    address:   RwLock<Option<Address>>,
-    consensus: RwLock<Option<F>>,
-    crypto:    RwLock<Option<C>>,
+    sender:    Pile<UnboundedSender<(Context, OverlordMsg<T>)>>,
+    state_rx:  Pile<UnboundedReceiver<(Context, OverlordMsg<T>)>>,
+    address:   Pile<Address>,
+    consensus: Pile<F>,
+    crypto:    Pile<C>,
     pin_txs:   PhantomData<S>,
 }
 
@@ -86,7 +88,9 @@ where
         });
 
         // Run state.
-        state.run(rx, evt_1).await
+        state.run(rx, evt_1).await?;
+
+        Ok(())
     }
 }
 

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use creep::Context;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::StreamExt;
+use log::error;
 use parking_lot::RwLock;
 
 use crate::error::ConsensusError;

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use creep::Context;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::StreamExt;
+use parking_lot::RwLock;
 
 use crate::error::ConsensusError;
 use crate::state::process::State;
@@ -12,11 +13,11 @@ use crate::{Codec, Consensus, ConsensusResult, Crypto};
 
 /// An overlord consensus instance.
 pub struct Overlord<T: Codec, S: Codec, F: Consensus<T, S>, C: Crypto> {
-    sender:    Option<UnboundedSender<(Context, OverlordMsg<T>)>>,
-    state_rx:  Option<UnboundedReceiver<(Context, OverlordMsg<T>)>>,
-    address:   Option<Address>,
-    consensus: Option<F>,
-    crypto:    Option<C>,
+    sender:    RwLock<Option<UnboundedSender<(Context, OverlordMsg<T>)>>>,
+    state_rx:  RwLock<Option<UnboundedReceiver<(Context, OverlordMsg<T>)>>>,
+    address:   RwLock<Option<Address>>,
+    consensus: RwLock<Option<F>>,
+    crypto:    RwLock<Option<C>>,
     pin_txs:   PhantomData<S>,
 }
 
@@ -31,40 +32,48 @@ where
     pub fn new(address: Address, consensus: F, crypto: C) -> Self {
         let (tx, rx) = unbounded();
         Overlord {
-            sender:    Some(tx),
-            state_rx:  Some(rx),
-            address:   Some(address),
-            consensus: Some(consensus),
-            crypto:    Some(crypto),
+            sender:    RwLock::new(Some(tx)),
+            state_rx:  RwLock::new(Some(rx)),
+            address:   RwLock::new(Some(address)),
+            consensus: RwLock::new(Some(consensus)),
+            crypto:    RwLock::new(Some(crypto)),
             pin_txs:   PhantomData,
         }
     }
 
     /// Take the overlord handler from the overlord instance.
-    pub fn take_handler(&mut self) -> OverlordHandler<T> {
-        assert!(self.sender.is_some());
-        OverlordHandler::new(self.sender.take().unwrap())
+    pub fn take_handler(&self) -> OverlordHandler<T> {
+        let mut sender = self.sender.write();
+        assert!(sender.is_some());
+        OverlordHandler::new(sender.take().unwrap())
     }
 
     /// Run overlord consensus process. The `interval` is the epoch interval as millisecond.
-    pub async fn run(mut self, interval: u64) -> ConsensusResult<()> {
+    pub async fn run(self, interval: u64) -> ConsensusResult<()> {
         let (mut smr_provider, evt_1, evt_2) = SMRProvider::new();
         let smr = smr_provider.take_smr();
         let mut timer = Timer::new(evt_2, smr.clone(), interval);
-        let state_rx = self.state_rx.take().unwrap();
+
+        let mut state_rx = self.state_rx.write();
+        let mut address = self.address.write();
+        let mut consensus = self.consensus.write();
+        let mut crypto = self.crypto.write();
+        let sender = self.sender.read();
+
+        let rx = state_rx.take().unwrap();
         let mut state = State::new(
             smr,
-            self.address.take().unwrap(),
+            address.take().unwrap(),
             interval,
-            self.consensus.take().unwrap(),
-            self.crypto.take().unwrap(),
+            consensus.take().unwrap(),
+            crypto.take().unwrap(),
         );
 
-        assert!(self.sender.is_none());
-        assert!(self.address.is_none());
-        assert!(self.consensus.is_none());
-        assert!(self.crypto.is_none());
-        assert!(self.state_rx.is_none());
+        assert!(sender.is_none());
+        assert!(address.is_none());
+        assert!(consensus.is_none());
+        assert!(crypto.is_none());
+        assert!(state_rx.is_none());
 
         // Run SMR.
         smr_provider.run();
@@ -77,7 +86,7 @@ where
         });
 
         // Run state.
-        state.run(state_rx, evt_1).await
+        state.run(rx, evt_1).await
     }
 }
 

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -70,7 +70,7 @@ where
         smr_provider.run();
 
         // Run timer.
-        tokio::spawn(async move {
+        runtime::spawn(async move {
             loop {
                 timer.next().await;
             }

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -47,7 +47,7 @@ where
     }
 
     /// Run overlord consensus process. The `interval` is the epoch interval as millisecond.
-    pub async fn run(mut self, interval: u64) {
+    pub async fn run(mut self, interval: u64) -> ConsensusResult<()> {
         let (mut smr_provider, evt_1, evt_2) = SMRProvider::new();
         let smr = smr_provider.take_smr();
         let mut timer = Timer::new(evt_2, smr.clone(), interval);
@@ -77,9 +77,7 @@ where
         });
 
         // Run state.
-        tokio::spawn(async move {
-            let _ = state.run(state_rx, evt_1).await;
-        });
+        state.run(state_rx, evt_1).await
     }
 }
 

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -43,15 +43,15 @@ where
         }
     }
 
-    /// Take the overlord handler from the overlord instance.
-    pub fn take_handler(&self) -> OverlordHandler<T> {
+    /// Get the overlord handler from the overlord instance.
+    pub fn get_handler(&self) -> OverlordHandler<T> {
         let mut sender = self.sender.write();
         assert!(sender.is_some());
         OverlordHandler::new(sender.take().unwrap())
     }
 
     /// Run overlord consensus process. The `interval` is the epoch interval as millisecond.
-    pub async fn run(self, interval: u64) -> ConsensusResult<()> {
+    pub async fn run(&self, interval: u64) -> ConsensusResult<()> {
         let (mut smr_provider, evt_1, evt_2) = SMRProvider::new();
         let smr = smr_provider.take_smr();
         let mut timer = Timer::new(evt_2, smr.clone(), interval);

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -56,26 +56,30 @@ where
         let smr = smr_provider.take_smr();
         let mut timer = Timer::new(evt_2, smr.clone(), interval);
 
-        let mut state_rx = self.state_rx.write();
-        let mut address = self.address.write();
-        let mut consensus = self.consensus.write();
-        let mut crypto = self.crypto.write();
-        let sender = self.sender.read();
+        let (rx, mut state) = {
+            let mut state_rx = self.state_rx.write();
+            let mut address = self.address.write();
+            let mut consensus = self.consensus.write();
+            let mut crypto = self.crypto.write();
+            let sender = self.sender.read();
 
-        let rx = state_rx.take().unwrap();
-        let mut state = State::new(
-            smr,
-            address.take().unwrap(),
-            interval,
-            consensus.take().unwrap(),
-            crypto.take().unwrap(),
-        );
+            let tmp_rx = state_rx.take().unwrap();
+            let tmp_state = State::new(
+                smr,
+                address.take().unwrap(),
+                interval,
+                consensus.take().unwrap(),
+                crypto.take().unwrap(),
+            );
 
-        assert!(sender.is_none());
-        assert!(address.is_none());
-        assert!(consensus.is_none());
-        assert!(crypto.is_none());
-        assert!(state_rx.is_none());
+            assert!(sender.is_none());
+            assert!(address.is_none());
+            assert!(consensus.is_none());
+            assert!(crypto.is_none());
+            assert!(state_rx.is_none());
+
+            (tmp_rx, tmp_state)
+        };
 
         // Run SMR.
         smr_provider.run();

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 use creep::Context;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::StreamExt;
-use log::error;
 use parking_lot::RwLock;
 
 use crate::error::ConsensusError;

--- a/src/overlord.rs
+++ b/src/overlord.rs
@@ -47,7 +47,7 @@ where
     }
 
     /// Run overlord consensus process. The `interval` is the epoch interval as millisecond.
-    pub fn run(mut self, interval: u64) {
+    pub async fn run(mut self, interval: u64) {
         let (mut smr_provider, evt_1, evt_2) = SMRProvider::new();
         let smr = smr_provider.take_smr();
         let mut timer = Timer::new(evt_2, smr.clone(), interval);

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -50,8 +50,8 @@ impl SMRProvider {
         runtime::spawn(async move {
             loop {
                 let res = self.state_machine.next().await;
-                if res.is_some() {
-                    error!("Overlord: SMR error {:?}", res.unwrap());
+                if let Some(err) = res {
+                    error!("Overlord: SMR error {:?}", err);
                 }
             }
         });

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -48,7 +48,9 @@ impl SMRProvider {
     pub fn run(mut self) {
         tokio::spawn(async move {
             loop {
+                println!("aaaaaa");
                 let _ = self.state_machine.next().await;
+                println!("bbbbbb");
             }
         });
     }

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -11,6 +11,7 @@ use std::task::{Context, Poll};
 
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::stream::{FusedStream, Stream, StreamExt};
+use log::error;
 
 use crate::smr::smr_types::{SMREvent, SMRTrigger, TriggerSource, TriggerType};
 use crate::smr::state_machine::StateMachine;
@@ -48,7 +49,10 @@ impl SMRProvider {
     pub fn run(mut self) {
         runtime::spawn(async move {
             loop {
-                let _ = self.state_machine.next().await;
+                let res = self.state_machine.next().await;
+                if res.is_some() {
+                    error!("Overlord: SMR error {:?}", res.unwrap());
+                }
             }
         });
     }

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -48,9 +48,7 @@ impl SMRProvider {
     pub fn run(mut self) {
         runtime::spawn(async move {
             loop {
-                println!("aaaaaa");
                 let _ = self.state_machine.next().await;
-                println!("bbbbbb");
             }
         });
     }
@@ -78,13 +76,15 @@ impl SMR {
 
     /// Trigger SMR to goto a new epoch.
     pub fn new_epoch(&mut self, epoch_id: u64) -> ConsensusResult<()> {
+        // TODO refactor
         let trigger = TriggerType::NewEpoch(epoch_id);
         self.tx
             .unbounded_send(SMRTrigger {
                 trigger_type: trigger.clone(),
-                source:       TriggerSource::State,
-                hash:         Hash::new(),
-                round:        None,
+                source: TriggerSource::State,
+                hash: Hash::new(),
+                round: None,
+                epoch_id,
             })
             .map_err(|_| ConsensusError::TriggerSMRErr(trigger.to_string()))
     }

--- a/src/smr/mod.rs
+++ b/src/smr/mod.rs
@@ -46,7 +46,7 @@ impl SMRProvider {
 
     /// Run SMR module in runtime environment.
     pub fn run(mut self) {
-        tokio::spawn(async move {
+        runtime::spawn(async move {
             loop {
                 println!("aaaaaa");
                 let _ = self.state_machine.next().await;

--- a/src/smr/smr_types.rs
+++ b/src/smr/smr_types.rs
@@ -52,6 +52,8 @@ impl Default for Step {
 }
 
 /// SMR event that state and timer monitor this.
+/// **NOTICE**: The `epoch_id` field is just for the timer. Timer will take this to signal the timer epoch ID.
+/// State will ignore this field on handling event.
 #[derive(Clone, Debug, Display, PartialEq, Eq)]
 pub enum SMREvent {
     /// New round event,
@@ -158,6 +160,8 @@ impl From<u8> for TriggerType {
 /// While trigger type is `NewEpoch`:
 ///     * `hash`: A empty hash,
 ///     * `round`: This must be `None`.
+/// For each sources, while filling the `SMRTrigger`, the `epoch_id` field take the current epoch ID
+/// directly.
 #[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "{:?} trigger from {:?}", trigger_type, source)]
 pub struct SMRTrigger {

--- a/src/smr/smr_types.rs
+++ b/src/smr/smr_types.rs
@@ -163,7 +163,12 @@ impl From<u8> for TriggerType {
 /// For each sources, while filling the `SMRTrigger`, the `epoch_id` field take the current epoch ID
 /// directly.
 #[derive(Clone, Debug, Display, PartialEq, Eq)]
-#[display(fmt = "{:?} trigger from {:?}", trigger_type, source)]
+#[display(
+    fmt = "{:?} trigger from {:?}, epoch ID {}",
+    trigger_type,
+    source,
+    epoch_id
+)]
 pub struct SMRTrigger {
     /// SMR trigger type.
     pub trigger_type: TriggerType,

--- a/src/smr/smr_types.rs
+++ b/src/smr/smr_types.rs
@@ -59,6 +59,7 @@ pub enum SMREvent {
     /// for timer: set a propose step timer. If `round == 0`, set an extra total epoch timer.
     #[display(fmt = "New round {} event", round)]
     NewRoundInfo {
+        epoch_id:      u64,
         round:         u64,
         lock_round:    Option<u64>,
         lock_proposal: Option<Hash>,
@@ -67,12 +68,20 @@ pub enum SMREvent {
     /// for state: transmit a prevote vote,
     /// for timer: set a prevote step timer.
     #[display(fmt = "Prevote event")]
-    PrevoteVote(Hash),
+    PrevoteVote {
+        epoch_id:   u64,
+        round:      u64,
+        epoch_hash: Hash,
+    },
     /// Precommit event,
     /// for state: transmit a precommit vote,
     /// for timer: set a precommit step timer.
     #[display(fmt = "Precommit event")]
-    PrecommitVote(Hash),
+    PrecommitVote {
+        epoch_id:   u64,
+        round:      u64,
+        epoch_hash: Hash,
+    },
     /// Commit event,
     /// for state: do commit,
     /// for timer: do nothing.
@@ -160,6 +169,9 @@ pub struct SMRTrigger {
     pub hash: Hash,
     /// SMR trigger round, the meaning shown above.
     pub round: Option<u64>,
+    /// **NOTICE**: This field is only for timer to signed timer's epoch ID. Therefore, the SMR can
+    /// filter out the outdated timers.
+    pub epoch_id: u64,
 }
 
 /// An inner lock struct.

--- a/src/smr/smr_types.rs
+++ b/src/smr/smr_types.rs
@@ -52,8 +52,8 @@ impl Default for Step {
 }
 
 /// SMR event that state and timer monitor this.
-/// **NOTICE**: The `epoch_id` field is just for the timer. Timer will take this to signal the timer epoch ID.
-/// State will ignore this field on handling event.
+/// **NOTICE**: The `epoch_id` field is just for the timer. Timer will take this to signal the timer
+/// epoch ID. State will ignore this field on handling event.
 #[derive(Clone, Debug, Display, PartialEq, Eq)]
 pub enum SMREvent {
     /// New round event,

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -115,7 +115,7 @@ impl StateMachine {
         lock_round: Option<u64>,
         _source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by a proposal");
+        info!("Overlord: SMR triggered by a proposal hash {:?}", proposal_hash);
 
         if self.step > Step::Propose {
             return Ok(());
@@ -159,7 +159,7 @@ impl StateMachine {
         prevote_round: Option<u64>,
         source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by prevote QC");
+        info!("Overlord: SMR triggered by prevote QC hash {:?}", prevote_hash);
 
         if self.step > Step::Prevote {
             return Ok(());
@@ -201,7 +201,7 @@ impl StateMachine {
         precommit_round: Option<u64>,
         _source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by precommit QC");
+        info!("Overlord: SMR triggered by precommit QC hash {:?}", precommit_hash);
 
         self.check()?;
         let precommit_round = precommit_round

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -125,13 +125,6 @@ impl StateMachine {
             return Ok(());
         }
 
-        log::warn!(
-            "self epoch ID {}, trigger epoch ID {}, from {:?}",
-            self.epoch_id,
-            epoch_id,
-            source
-        );
-
         if self.step > Step::Propose {
             return Ok(());
         }

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -115,7 +115,10 @@ impl StateMachine {
         lock_round: Option<u64>,
         _source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by a proposal hash {:?}", proposal_hash);
+        info!(
+            "Overlord: SMR triggered by a proposal hash {:?}",
+            proposal_hash
+        );
 
         if self.step > Step::Propose {
             return Ok(());
@@ -159,7 +162,10 @@ impl StateMachine {
         prevote_round: Option<u64>,
         source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by prevote QC hash {:?}", prevote_hash);
+        info!(
+            "Overlord: SMR triggered by prevote QC hash {:?}",
+            prevote_hash
+        );
 
         if self.step > Step::Prevote {
             return Ok(());
@@ -201,7 +207,14 @@ impl StateMachine {
         precommit_round: Option<u64>,
         _source: TriggerSource,
     ) -> ConsensusResult<()> {
-        info!("Overlord: SMR triggered by precommit QC hash {:?}", precommit_hash);
+        info!(
+            "Overlord: SMR triggered by precommit QC hash {:?}",
+            precommit_hash
+        );
+
+        if self.step > Step::Precommit {
+            return Ok(());
+        }
 
         self.check()?;
         let precommit_round = precommit_round

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -126,9 +126,10 @@ impl StateMachine {
         }
 
         log::warn!(
-            "self epoch ID {}, trigger epoch ID {}",
+            "self epoch ID {}, trigger epoch ID {}, from {:?}",
             self.epoch_id,
-            epoch_id
+            epoch_id,
+            source
         );
 
         if self.step > Step::Propose {

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -216,6 +216,10 @@ impl StateMachine {
             } else {
                 self.update_polc(prevote_hash.clone(), vote_round);
             }
+        } else {
+            if self.lock.is_none() {
+                self.proposal_hash.clear();
+            }
         }
 
         // throw precommit vote event

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -125,6 +125,12 @@ impl StateMachine {
             return Ok(());
         }
 
+        log::warn!(
+            "self epoch ID {}, trigger epoch ID {}",
+            self.epoch_id,
+            epoch_id
+        );
+
         if self.step > Step::Propose {
             return Ok(());
         }

--- a/src/smr/state_machine.rs
+++ b/src/smr/state_machine.rs
@@ -216,10 +216,9 @@ impl StateMachine {
             } else {
                 self.update_polc(prevote_hash.clone(), vote_round);
             }
-        } else {
-            if self.lock.is_none() {
-                self.proposal_hash.clear();
-            }
+        } else if self.lock.is_none() {
+            // If the trigger source is timer and does not have a lock, clear the proposal hash.
+            self.proposal_hash.clear();
         }
 
         // throw precommit vote event

--- a/src/smr/tests/new_epoch_test.rs
+++ b/src/smr/tests/new_epoch_test.rs
@@ -2,8 +2,8 @@ use crate::smr::smr_types::{Lock, SMREvent, SMRTrigger, Step, TriggerType};
 use crate::smr::tests::{gen_hash, trigger_test, InnerState, StateMachineTestCase};
 use crate::{error::ConsensusError, types::Hash};
 
-#[test]
-fn test_new_epoch() {
+#[runtime::test]
+async fn test_new_epoch() {
     let mut index = 1;
     let mut test_cases: Vec<StateMachineTestCase> = Vec::new();
 
@@ -12,8 +12,9 @@ fn test_new_epoch() {
     // The output should be new round info.
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -32,8 +33,9 @@ fn test_new_epoch() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash, Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -49,8 +51,9 @@ fn test_new_epoch() {
     let lock = Lock::new(0u64, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -65,8 +68,9 @@ fn test_new_epoch() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -81,8 +85,9 @@ fn test_new_epoch() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -97,8 +102,9 @@ fn test_new_epoch() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, hash, None),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -114,8 +120,9 @@ fn test_new_epoch() {
     let lock = Lock::new(0u64, hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash, Some(lock)),
-        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None),
+        SMRTrigger::new(Hash::new(), TriggerType::NewEpoch(1), None, 0),
         SMREvent::NewRoundInfo {
+            epoch_id:      1u64,
             round:         0u64,
             lock_round:    None,
             lock_proposal: None,
@@ -133,7 +140,8 @@ fn test_new_epoch() {
             case.output,
             case.err,
             case.should_lock,
-        );
+        )
+        .await;
     }
     println!("New epoch test success");
 }

--- a/src/smr/tests/prevote_test.rs
+++ b/src/smr/tests/prevote_test.rs
@@ -4,8 +4,8 @@ use crate::{error::ConsensusError, types::Hash};
 
 /// Test state machine handle prevoteQC trigger.
 /// There are a total of *2 × 4 + 2 = 10* test cases.
-#[test]
-fn test_prevote_trigger() {
+#[runtime::test]
+async fn test_prevote_trigger() {
     let mut index = 1;
     let mut test_cases: Vec<StateMachineTestCase> = Vec::new();
 
@@ -15,8 +15,12 @@ fn test_prevote_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0)),
-        SMREvent::PrecommitVote(hash.clone()),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: hash.clone(),
+        },
         None,
         Some((0, hash)),
     ));
@@ -27,8 +31,12 @@ fn test_prevote_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0)),
-        SMREvent::PrecommitVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(0), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: hash,
+        },
         None,
         None,
     ));
@@ -44,8 +52,12 @@ fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash.clone(),
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         Some((0, lock_hash)),
     ));
@@ -61,8 +73,12 @@ fn test_prevote_trigger() {
     };
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, Hash::new(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash.clone(),
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         Some((0, lock_hash)),
     ));
@@ -73,8 +89,12 @@ fn test_prevote_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(Hash::new()),
+        SMRTrigger::new(Hash::new(), TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: Hash::new(),
+        },
         None,
         None,
     ));
@@ -86,8 +106,12 @@ fn test_prevote_trigger() {
     let vote_hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, hash.clone(), None),
-        SMRTrigger::new(vote_hash.clone(), TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(vote_hash.clone()),
+        SMRTrigger::new(vote_hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: vote_hash.clone(),
+        },
         None,
         Some((1, vote_hash)),
     ));
@@ -100,8 +124,12 @@ fn test_prevote_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(hash.clone()),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash.clone(),
+        },
         None,
         None,
     ));
@@ -114,23 +142,31 @@ fn test_prevote_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1)),
-        SMREvent::PrecommitVote(hash.clone()),
+        SMRTrigger::new(hash.clone(), TriggerType::PrevoteQC, Some(1), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash.clone(),
+        },
         None,
         Some((1, hash)),
     ));
 
-    // Test case 09:
-    //      the prevote round is not equal to self round.
-    // This is an incorrect situation, the process will return round diff err.
-    let hash = gen_hash();
-    test_cases.push(StateMachineTestCase::new(
-        InnerState::new(1, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(0)),
-        SMREvent::PrecommitVote(Hash::new()),
-        Some(ConsensusError::RoundDiff { local: 1, vote: 0 }),
-        None,
-    ));
+    // // Test case 09:
+    // //      the prevote round is not equal to self round.
+    // // This is an incorrect situation, the process will return round diff err.
+    // let hash = gen_hash();
+    // test_cases.push(StateMachineTestCase::new(
+    //     InnerState::new(1, Step::Prevote, Hash::new(), None),
+    //     SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(0), 0),
+    //     SMREvent::PrecommitVote {
+    //         epoch_id:   0u64,
+    //         round:      1u64,
+    //         epoch_hash: Hash::new(),
+    //     },
+    //     Some(ConsensusError::RoundDiff { local: 1, vote: 0 }),
+    //     None,
+    // ));
 
     // Test case 10:
     //      the prevote round is not equal to self round.
@@ -138,8 +174,12 @@ fn test_prevote_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Prevote, Hash::new(), None),
-        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(2)),
-        SMREvent::PrecommitVote(Hash::new()),
+        SMRTrigger::new(hash, TriggerType::PrevoteQC, Some(2), 0),
+        SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: Hash::new(),
+        },
         Some(ConsensusError::RoundDiff { local: 1, vote: 2 }),
         None,
     ));
@@ -153,7 +193,8 @@ fn test_prevote_trigger() {
             case.output,
             case.err,
             case.should_lock,
-        );
+        )
+        .await;
     }
     println!("Prevote test success");
 }

--- a/src/smr/tests/proposal_test.rs
+++ b/src/smr/tests/proposal_test.rs
@@ -4,8 +4,8 @@ use crate::{error::ConsensusError, types::Hash};
 
 /// Test state machine handle proposal trigger.
 /// There are a total of *4 × 4 + 3 = 19* test cases.
-#[test]
-fn test_proposal_trigger() {
+#[runtime::test]
+async fn test_proposal_trigger() {
     let mut index = 1;
     let mut test_cases: Vec<StateMachineTestCase> = Vec::new();
 
@@ -16,8 +16,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: hash,
+        },
         None,
         None,
     ));
@@ -29,8 +33,12 @@ fn test_proposal_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(0, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: hash,
+        },
         None,
         None,
     ));
@@ -42,8 +50,12 @@ fn test_proposal_trigger() {
     let hash = Hash::new();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::ProposalErr("Invalid lock".to_string())),
         None,
     ));
@@ -55,8 +67,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, Hash::new(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         None,
         None,
     ));
@@ -68,8 +84,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -81,8 +101,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -94,8 +118,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(Hash::new(), TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -107,8 +135,12 @@ fn test_proposal_trigger() {
     let hash = gen_hash();
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), None),
-        SMRTrigger::new(Hash::new(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(Hash::new(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -122,8 +154,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -137,8 +173,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -152,8 +192,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash);
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -167,8 +211,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, hash, Some(lock)),
-        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(lock_hash),
+        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash,
+        },
         Some(ConsensusError::SelfCheckErr("".to_string())),
         None,
     ));
@@ -182,8 +230,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash.clone(),
+        },
         None,
         Some((0, lock_hash)),
     ));
@@ -197,8 +249,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, None),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::Proposal, None, 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash.clone(),
+        },
         None,
         Some((0, lock_hash)),
     ));
@@ -212,8 +268,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(0, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(1, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      1u64,
+            epoch_hash: lock_hash.clone(),
+        },
         Some(ConsensusError::ProposalErr("Invalid lock".to_string())),
         Some((0, lock_hash)),
     ));
@@ -228,8 +288,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(0)),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(0), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      2u64,
+            epoch_hash: lock_hash.clone(),
+        },
         None,
         Some((1, lock_hash)),
     ));
@@ -244,8 +308,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(3, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(2)),
-        SMREvent::PrevoteVote(hash),
+        SMRTrigger::new(hash.clone(), TriggerType::Proposal, Some(2), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      3u64,
+            epoch_hash: hash,
+        },
         None,
         None,
     ));
@@ -259,8 +327,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, Some(1)),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(lock_hash.clone(), TriggerType::Proposal, Some(1), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      2u64,
+            epoch_hash: lock_hash.clone(),
+        },
         None,
         Some((1, lock_hash)),
     ));
@@ -277,8 +349,12 @@ fn test_proposal_trigger() {
     let lock = Lock::new(1, lock_hash.clone());
     test_cases.push(StateMachineTestCase::new(
         InnerState::new(2, Step::Propose, lock_hash.clone(), Some(lock)),
-        SMRTrigger::new(hash, TriggerType::Proposal, Some(1)),
-        SMREvent::PrevoteVote(lock_hash.clone()),
+        SMRTrigger::new(hash, TriggerType::Proposal, Some(1), 0),
+        SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      2u64,
+            epoch_hash: lock_hash.clone(),
+        },
         Some(ConsensusError::CorrectnessErr("Fork".to_string())),
         Some((1, lock_hash)),
     ));
@@ -292,7 +368,8 @@ fn test_proposal_trigger() {
             case.output,
             case.err,
             case.should_lock,
-        );
+        )
+        .await;
     }
     println!("Proposal test success");
 }

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -337,8 +337,8 @@ where
         let round = signed_proposal.proposal.round;
 
         info!(
-            "Overlod: state receive a signed proposal epoch ID {}, round {}",
-            epoch_id, round
+            "Overlod: state receive a signed proposal epoch ID {}, round {}, from {:?}",
+            epoch_id, round, signed_proposal.proposal.epoch_hash
         );
 
         // If the proposal epoch ID is lower than the current epoch ID - 1, or the proposal epoch ID
@@ -589,8 +589,8 @@ where
         };
 
         info!(
-            "Overlord: state receive a signed {:?} vote epoch ID {}, round {}",
-            vote_type, epoch_id, round
+            "Overlord: state receive a signed {:?} vote epoch ID {}, round {}, from {:?}",
+            vote_type, epoch_id, round, signed_vote.vote.epoch_hash,
         );
 
         // If the vote epoch ID is lower than the current epoch ID - 1, or the vote epoch ID
@@ -712,8 +712,8 @@ where
         };
 
         info!(
-            "Overlord: state receive an {:?} QC epoch {}, round {}",
-            qc_type, epoch_id, round
+            "Overlord: state receive an {:?} QC epoch {}, round {}, from {:?}",
+            qc_type, epoch_id, round, aggregated_vote.epoch_hash
         );
 
         // If the vote epoch ID is lower than the current epoch ID - 1, or the vote epoch ID

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -300,6 +300,7 @@ where
         )
         .await?;
 
+        error!("{:?}", Instant::now() - self.epoch_start);
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
             source:       TriggerSource::State,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -544,7 +544,6 @@ where
             .await
             .map_err(|err| ConsensusError::Other(format!("commit error {:?}", err)))?;
 
-        let now = Instant::now();
         if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
             Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
                 .await

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -162,6 +162,7 @@ where
         // Update epoch ID and authority list.
         self.epoch_id = new_epoch_id;
         self.round = INIT_ROUND;
+        self.epoch_start = Instant::now();
         let mut auth_list = status.authority_list;
         self.authority.update(&mut auth_list, true);
 
@@ -545,13 +546,11 @@ where
         error!("commit finish");
 
         let now = Instant::now();
-        // if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
-        //     Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
-        //         .await
-        //         .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
-        // }
-
-        Delay::new(Duration::from_secs(3)).await.unwrap();
+        if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
+            Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
+                .await
+                .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
+        }
 
         error!("{:?}", Instant::now() - now);
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -302,7 +302,7 @@ where
         let epoch_id = self.epoch_id;
         let tx_signal = Arc::clone(&self.full_transcation);
         let function = Arc::clone(&self.function);
-        tokio::spawn(async move {
+        runtime::spawn(async move {
             let _ =
                 check_current_epoch(ctx.clone(), function, tx_signal, epoch_id, hash, epoch).await;
         });
@@ -423,7 +423,7 @@ where
         let tx_signal = Arc::clone(&self.full_transcation);
         let function = Arc::clone(&self.function);
 
-        tokio::spawn(async move {
+        runtime::spawn(async move {
             let _ = check_current_epoch(ctx, function, tx_signal, epoch_id, hash, epoch).await;
         });
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -278,6 +278,8 @@ where
             (epoch.to_owned(), hash, Some(polc))
         };
 
+        self.hash_with_epoch.insert(hash.clone(), epoch.clone());
+
         let proposal = Proposal {
             epoch_id:   self.epoch_id,
             round:      self.round,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -171,7 +171,9 @@ where
                 .function
                 .get_authority_list(ctx, new_epoch_id - 1)
                 .await
-                .map_err(|err| ConsensusError::Other(format!("get authority list error {:?}", err)))?;
+                .map_err(|err| {
+                    ConsensusError::Other(format!("get authority list error {:?}", err))
+                })?;
             self.authority.set_last_list(&mut tmp);
         }
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -300,8 +300,6 @@ where
         )
         .await?;
 
-        error!("{:?}", Instant::now() - self.epoch_start);
-
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
             source:       TriggerSource::State,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -542,6 +542,8 @@ where
             .await
             .map_err(|err| ConsensusError::Other(format!("commit error {:?}", err)))?;
 
+        error!("commit finish");
+
         let now = Instant::now();
         if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
             Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
@@ -549,7 +551,7 @@ where
                 .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
         }
 
-        log::error!("{:?}", Instant::now() - now);
+        error!("{:?}", Instant::now() - now);
 
         self.goto_new_epoch(ctx, status).await?;
         Ok(())

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -545,11 +545,13 @@ where
         error!("commit finish");
 
         let now = Instant::now();
-        if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
-            Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
-                .await
-                .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
-        }
+        // if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
+        //     Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
+        //         .await
+        //         .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
+        // }
+
+        Delay::new(Duration::from_secs(3)).await.unwrap();
 
         error!("{:?}", Instant::now() - now);
 

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -171,7 +171,7 @@ where
                 .function
                 .get_authority_list(ctx, new_epoch_id - 1)
                 .await
-                .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+                .map_err(|err| ConsensusError::Other(format!("get authority list error {:?}", err)))?;
             self.authority.set_last_list(&mut tmp);
         }
 
@@ -255,7 +255,7 @@ where
                 self.function
                     .get_epoch(ctx.clone(), self.epoch_id)
                     .await
-                    .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+                    .map_err(|err| ConsensusError::Other(format!("get epoch error {:?}", err)))?;
             (new_epoch, new_hash, None)
         } else {
             let round = lock_round.clone().unwrap();
@@ -532,7 +532,7 @@ where
             .function
             .commit(ctx.clone(), epoch, commit)
             .await
-            .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusError::Other(format!("commit error {:?}", err)))?;
 
         if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
             Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
@@ -1100,7 +1100,7 @@ where
         self.function
             .transmit_to_relayer(ctx, self.leader_address.clone(), msg)
             .await
-            .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusError::Other(format!("transmit error {:?}", err)))?;
         Ok(())
     }
 
@@ -1129,7 +1129,7 @@ where
                 OverlordMsg::SignedVote(self.sign_vote(vote)?),
             )
             .await
-            .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusError::Other(format!("transmit error {:?}", err)))?;
         Ok(())
     }
 
@@ -1142,7 +1142,7 @@ where
         self.function
             .broadcast_to_other(ctx, msg)
             .await
-            .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+            .map_err(|err| ConsensusError::Other(format!("broadcast error {:?}", err)))?;
         Ok(())
     }
 
@@ -1190,7 +1190,7 @@ async fn check_current_epoch<U: Consensus<T, S>, T: Codec, S: Codec>(
     let _transcation = function
         .check_epoch(ctx, epoch_id, hash.clone(), epoch)
         .await
-        .map_err(|err| ConsensusError::Other(format!("{:?}", err)))?;
+        .map_err(|err| ConsensusError::Other(format!("Check current epoch {:?}", err)))?;
     let mut set = tx_signal.lock();
     set.insert(hash);
     // TODO: write Wal

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -301,7 +301,7 @@ where
         .await?;
 
         error!("{:?}", Instant::now() - self.epoch_start);
-        
+
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
             source:       TriggerSource::State,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -420,6 +420,8 @@ where
             round:        lock_round,
         })?;
 
+        log::warn!("{:?}", self.hash_with_epoch);
+
         info!("Overlord: state check the whole epoch");
         let epoch_id = self.epoch_id;
         let tx_signal = Arc::clone(&self.full_transcation);
@@ -493,6 +495,8 @@ where
             "Overlord: state receive commit event epoch ID {}, round {}",
             self.epoch_id, self.round
         );
+
+        log::warn!("{:?}", self.hash_with_epoch);
 
         trace!("Overlord: state get origin epoch");
         let epoch = self.epoch_id;

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -301,6 +301,7 @@ where
         .await?;
 
         error!("{:?}", Instant::now() - self.epoch_start);
+        
         self.state_machine.trigger(SMRTrigger {
             trigger_type: TriggerType::Proposal,
             source:       TriggerSource::State,

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -307,8 +307,15 @@ where
             source:       TriggerSource::State,
             hash:         hash.clone(),
             round:        lock_round,
-            epoch_id:     self.round,
+            epoch_id:     self.epoch_id,
         })?;
+
+        info!(
+            "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+            self.epoch_id,
+            self.round,
+            TriggerType::Proposal
+        );
 
         let epoch_id = self.epoch_id;
         let tx_signal = Arc::clone(&self.full_transcation);
@@ -429,6 +436,13 @@ where
             round:        lock_round,
             epoch_id:     self.epoch_id,
         })?;
+
+        info!(
+            "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+            self.epoch_id,
+            self.round,
+            TriggerType::Proposal
+        );
 
         info!("Overlord: state check the whole epoch");
         let epoch_id = self.epoch_id;
@@ -657,12 +671,18 @@ where
             vote_type, self.epoch_id, self.round
         );
         self.state_machine.trigger(SMRTrigger {
-            trigger_type: vote_type.into(),
+            trigger_type: vote_type.clone().into(),
             source:       TriggerSource::State,
             hash:         epoch_hash,
             round:        Some(round),
             epoch_id:     self.epoch_id,
         })?;
+
+        info!(
+            "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+            self.epoch_id, self.round, vote_type,
+        );
+
         Ok(())
     }
 
@@ -765,12 +785,18 @@ where
         );
 
         self.state_machine.trigger(SMRTrigger {
-            trigger_type: qc_type.into(),
+            trigger_type: qc_type.clone().into(),
             source:       TriggerSource::State,
             hash:         epoch_hash,
             round:        Some(round),
             epoch_id:     self.epoch_id,
         })?;
+
+        info!(
+            "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+            self.epoch_id, self.round, qc_type,
+        );
+
         Ok(())
     }
 
@@ -787,12 +813,18 @@ where
                 .get_qc(self.epoch_id, self.round, vote_type.clone())
             {
                 self.state_machine.trigger(SMRTrigger {
-                    trigger_type: qc.vote_type.into(),
+                    trigger_type: qc.vote_type.clone().into(),
                     source:       TriggerSource::State,
                     hash:         qc.epoch_hash,
                     round:        Some(self.round),
                     epoch_id:     self.epoch_id,
                 })?;
+
+                info!(
+                    "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+                    self.epoch_id, self.round, qc.vote_type,
+                );
+
                 return Ok(());
             }
         } else if let Some(mut epoch_hash) = self.counting_vote(vote_type.clone())? {
@@ -817,12 +849,17 @@ where
             );
 
             self.state_machine.trigger(SMRTrigger {
-                trigger_type: vote_type.into(),
+                trigger_type: vote_type.clone().into(),
                 source:       TriggerSource::State,
                 hash:         epoch_hash,
                 round:        Some(self.round),
                 epoch_id:     self.epoch_id,
             })?;
+
+            info!(
+                "Overlord: state tigger SMR epoch ID {}, round {}, type {:?}",
+                self.epoch_id, self.round, vote_type,
+            );
         }
         Ok(())
     }

--- a/src/state/process.rs
+++ b/src/state/process.rs
@@ -542,11 +542,14 @@ where
             .await
             .map_err(|err| ConsensusError::Other(format!("commit error {:?}", err)))?;
 
+        let now = Instant::now();
         if Instant::now() < self.epoch_start + Duration::from_millis(self.epoch_interval) {
             Delay::new_at(self.epoch_start + Duration::from_millis(self.epoch_interval))
                 .await
                 .map_err(|err| ConsensusError::Other(format!("Overlord delay error {:?}", err)))?;
         }
+
+        log::error!("{:?}", Instant::now() - now);
 
         self.goto_new_epoch(ctx, status).await?;
         Ok(())

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,12 +1,12 @@
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{future::Future, pin::Pin};
 
 use derive_more::Display;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
 use futures::stream::{Stream, StreamExt};
 use futures::{FutureExt, SinkExt};
-use futures_timer::{Delay, TimerHandle};
+use futures_timer::Delay;
 use log::{debug, info};
 
 use crate::smr::smr_types::{SMREvent, SMRTrigger, TriggerSource, TriggerType};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -102,7 +102,7 @@ impl Timer {
         info!("Overlord: timer set {:?} timer", event);
         let smr_timer = TimeoutInfo::new(interval, event, self.sender.clone());
 
-        tokio::spawn(async move {
+        runtime::spawn(async move {
             smr_timer.await;
         });
 
@@ -147,7 +147,7 @@ impl Future for TimeoutInfo {
         match self.timeout.poll_unpin(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(_) => {
-                tokio::spawn(async move {
+                runtime::spawn(async move {
                     let _ = tx.send(msg).await;
                 });
                 Poll::Ready(())

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -129,9 +129,16 @@ impl Timer {
         Ok(())
     }
 
+    /// **TODO**: refactor filter here.
+    #[rustfmt::skip]
     fn trigger(&mut self, event: SMREvent) -> ConsensusResult<()> {
         let (trigger_type, round, epoch_id) = match event {
-            SMREvent::NewRoundInfo { epoch_id, .. } => (TriggerType::Proposal, None, epoch_id),
+            SMREvent::NewRoundInfo { epoch_id, round, .. } => {
+                if round < self.round {
+                    return Ok(());
+                }
+                (TriggerType::Proposal, None, epoch_id)
+            }
 
             SMREvent::PrevoteVote {
                 epoch_id, round, ..

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -18,12 +18,13 @@ use crate::{types::Hash, utils::timer_config::TimerConfig};
 /// timer will get timeout interval from timer config, then set a delay. When the timeout expires,
 #[derive(Debug)]
 pub struct Timer {
-    config: TimerConfig,
-    event:  Event,
-    sender: UnboundedSender<SMREvent>,
-    notify: UnboundedReceiver<SMREvent>,
-    smr:    SMR,
-    round:  u64,
+    config:   TimerConfig,
+    event:    Event,
+    sender:   UnboundedSender<SMREvent>,
+    notify:   UnboundedReceiver<SMREvent>,
+    smr:      SMR,
+    epoch_id: u64,
+    round:    u64,
 }
 
 ///
@@ -83,6 +84,7 @@ impl Timer {
         let (tx, rx) = unbounded();
         Timer {
             config: TimerConfig::new(interval),
+            epoch_id: 0u64,
             round: INIT_ROUND,
             sender: tx,
             notify: rx,
@@ -94,7 +96,12 @@ impl Timer {
     fn set_timer(&mut self, event: SMREvent) -> ConsensusResult<()> {
         let mut is_propose_timer = false;
         match event.clone() {
-            SMREvent::NewRoundInfo { round, .. } => {
+            SMREvent::NewRoundInfo {
+                epoch_id, round, ..
+            } => {
+                if epoch_id > self.epoch_id {
+                    self.epoch_id = epoch_id;
+                }
                 self.round = round;
                 is_propose_timer = true;
             }
@@ -123,10 +130,14 @@ impl Timer {
     }
 
     fn trigger(&mut self, event: SMREvent) -> ConsensusResult<()> {
-        let (trigger_type, round) = match event {
-            SMREvent::NewRoundInfo { .. } => (TriggerType::Proposal, None),
-            SMREvent::PrevoteVote(_) => (TriggerType::PrevoteQC, Some(self.round)),
-            SMREvent::PrecommitVote(_) => (TriggerType::PrecommitQC, Some(self.round)),
+        let (trigger_type, round, epoch_id) = match event {
+            SMREvent::NewRoundInfo { epoch_id, .. } => (TriggerType::Proposal, None, epoch_id),
+            SMREvent::PrevoteVote {
+                epoch_id, round, ..
+            } => (TriggerType::PrevoteQC, Some(round), epoch_id),
+            SMREvent::PrecommitVote {
+                epoch_id, round, ..
+            } => (TriggerType::PrecommitQC, Some(round), epoch_id),
             _ => return Err(ConsensusError::TimerErr("No commit timer".to_string())),
         };
 
@@ -136,6 +147,7 @@ impl Timer {
             hash: Hash::new(),
             trigger_type,
             round,
+            epoch_id,
         })
     }
 }
@@ -186,20 +198,18 @@ impl TimeoutInfo {
 mod test {
     use futures::channel::mpsc::unbounded;
     use futures::stream::StreamExt;
-    use tokio::runtime::Runtime;
 
     use crate::smr::smr_types::{SMREvent, SMRTrigger, TriggerSource, TriggerType};
     use crate::smr::{Event, SMR};
     use crate::{timer::Timer, types::Hash};
 
-    fn test_timer_trigger(input: SMREvent, output: SMRTrigger) {
+    async fn test_timer_trigger(input: SMREvent, output: SMRTrigger) {
         let (trigger_tx, mut trigger_rx) = unbounded();
         let (event_tx, event_rx) = unbounded();
         let mut timer = Timer::new(Event::new(event_rx), SMR::new(trigger_tx), 3000);
         event_tx.unbounded_send(input).unwrap();
 
-        let rt = Runtime::new().unwrap();
-        rt.spawn(async move {
+        runtime::spawn(async move {
             loop {
                 match timer.next().await {
                     None => break,
@@ -208,64 +218,85 @@ mod test {
             }
         });
 
-        rt.block_on(async move {
-            if let Some(res) = trigger_rx.next().await {
-                assert_eq!(res, output);
-                event_tx.unbounded_send(SMREvent::Stop).unwrap();
-            }
-        })
+        if let Some(res) = trigger_rx.next().await {
+            assert_eq!(res, output);
+            event_tx.unbounded_send(SMREvent::Stop).unwrap();
+        }
     }
 
-    fn gen_output(trigger_type: TriggerType, round: Option<u64>) -> SMRTrigger {
+    fn gen_output(trigger_type: TriggerType, round: Option<u64>, epoch_id: u64) -> SMRTrigger {
         SMRTrigger {
             source: TriggerSource::Timer,
             hash: Hash::new(),
             trigger_type,
             round,
+            epoch_id,
         }
     }
 
-    #[test]
-    fn test_correctness() {
+    #[runtime::test]
+    async fn test_correctness() {
         // Test propose step timer.
         test_timer_trigger(
             SMREvent::NewRoundInfo {
+                epoch_id:      0,
                 round:         0,
                 lock_round:    None,
                 lock_proposal: None,
             },
-            gen_output(TriggerType::Proposal, None),
-        );
+            gen_output(TriggerType::Proposal, None, 0),
+        )
+        .await;
 
         // Test prevote step timer.
         test_timer_trigger(
-            SMREvent::PrevoteVote(Hash::new()),
-            gen_output(TriggerType::PrevoteQC, Some(0)),
-        );
+            SMREvent::PrevoteVote {
+                epoch_id:   0u64,
+                round:      0u64,
+                epoch_hash: Hash::new(),
+            },
+            gen_output(TriggerType::PrevoteQC, Some(0), 0),
+        )
+        .await;
 
         // Test precommit step timer.
         test_timer_trigger(
-            SMREvent::PrecommitVote(Hash::new()),
-            gen_output(TriggerType::PrecommitQC, Some(0)),
-        );
+            SMREvent::PrecommitVote {
+                epoch_id:   0u64,
+                round:      0u64,
+                epoch_hash: Hash::new(),
+            },
+            gen_output(TriggerType::PrecommitQC, Some(0), 0),
+        )
+        .await;
     }
 
-    #[test]
-    fn test_order() {
+    #[runtime::test]
+    async fn test_order() {
         let (trigger_tx, mut trigger_rx) = unbounded();
         let (event_tx, event_rx) = unbounded();
         let mut timer = Timer::new(Event::new(event_rx), SMR::new(trigger_tx), 3000);
 
         let new_round_event = SMREvent::NewRoundInfo {
+            epoch_id:      0,
             round:         0,
             lock_round:    None,
             lock_proposal: None,
         };
-        let prevote_event = SMREvent::PrevoteVote(Hash::new());
-        let precommit_event = SMREvent::PrecommitVote(Hash::new());
 
-        let rt = Runtime::new().unwrap();
-        rt.spawn(async move {
+        let prevote_event = SMREvent::PrevoteVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: Hash::new(),
+        };
+
+        let precommit_event = SMREvent::PrecommitVote {
+            epoch_id:   0u64,
+            round:      0u64,
+            epoch_hash: Hash::new(),
+        };
+
+        runtime::spawn(async move {
             loop {
                 match timer.next().await {
                     None => break,
@@ -278,25 +309,23 @@ mod test {
         event_tx.unbounded_send(prevote_event).unwrap();
         event_tx.unbounded_send(precommit_event).unwrap();
 
-        rt.block_on(async move {
-            let mut count = 1u32;
-            let mut output = Vec::new();
-            let predict = vec![
-                gen_output(TriggerType::PrecommitQC, Some(0)),
-                gen_output(TriggerType::PrevoteQC, Some(0)),
-                gen_output(TriggerType::Proposal, None),
-            ];
+        let mut count = 1u32;
+        let mut output = Vec::new();
+        let predict = vec![
+            gen_output(TriggerType::PrecommitQC, Some(0), 0),
+            gen_output(TriggerType::PrevoteQC, Some(0), 0),
+            gen_output(TriggerType::Proposal, None, 0),
+        ];
 
-            while let Some(res) = trigger_rx.next().await {
-                output.push(res);
-                if count != 3 {
-                    count += 1;
-                } else {
-                    assert_eq!(predict, output);
-                    event_tx.unbounded_send(SMREvent::Stop).unwrap();
-                    return;
-                }
+        while let Some(res) = trigger_rx.next().await {
+            output.push(res);
+            if count != 3 {
+                count += 1;
+            } else {
+                assert_eq!(predict, output);
+                event_tx.unbounded_send(SMREvent::Stop).unwrap();
+                return;
             }
-        })
+        }
     }
 }

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -120,7 +120,7 @@ impl Timer {
         }
 
         info!("Overlord: timer set {:?} timer", event);
-        log::error!("{:?}", interval);   
+        log::error!("{:?}", interval);
 
         let smr_timer = TimeoutInfo::new(interval, event, self.sender.clone());
 
@@ -197,8 +197,10 @@ impl Future for TimeoutInfo {
 
 impl TimeoutInfo {
     fn new(interval: Duration, event: SMREvent, tx: UnboundedSender<SMREvent>) -> Self {
-        let mut delay = Delay::new_handle(Instant::now(), TimerHandle::default());
-        delay.reset(interval);
+        // let mut delay = Delay::new_handle(Instant::now(), TimerHandle::default());
+        // delay.reset(interval);
+
+        let delay = Delay::new(interval);
 
         TimeoutInfo {
             timeout: delay,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -120,6 +120,8 @@ impl Timer {
         }
 
         info!("Overlord: timer set {:?} timer", event);
+        log::error!("{:?}", interval);   
+
         let smr_timer = TimeoutInfo::new(interval, event, self.sender.clone());
 
         runtime::spawn(async move {
@@ -151,7 +153,9 @@ impl Timer {
             _ => return Err(ConsensusError::TimerErr("No commit timer".to_string())),
         };
 
-        debug!("Overlord: timer {:?} time out", event);
+        // TODO should be debug!
+        log::error!("Overlord: timer {:?} time out", event);
+
         self.smr.trigger(SMRTrigger {
             source: TriggerSource::Timer,
             hash: Hash::new(),

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -120,7 +120,6 @@ impl Timer {
         }
 
         info!("Overlord: timer set {:?} timer", event);
-        log::error!("{:?}", interval);
 
         let smr_timer = TimeoutInfo::new(interval, event, self.sender.clone());
 
@@ -154,7 +153,7 @@ impl Timer {
         };
 
         // TODO should be debug!
-        log::error!("Overlord: timer {:?} time out", event);
+        debug!("Overlord: timer {:?} time out", event);
 
         self.smr.trigger(SMRTrigger {
             source: TriggerSource::Timer,

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -132,12 +132,15 @@ impl Timer {
     fn trigger(&mut self, event: SMREvent) -> ConsensusResult<()> {
         let (trigger_type, round, epoch_id) = match event {
             SMREvent::NewRoundInfo { epoch_id, .. } => (TriggerType::Proposal, None, epoch_id),
+
             SMREvent::PrevoteVote {
                 epoch_id, round, ..
             } => (TriggerType::PrevoteQC, Some(round), epoch_id),
+
             SMREvent::PrecommitVote {
                 epoch_id, round, ..
             } => (TriggerType::PrecommitQC, Some(round), epoch_id),
+
             _ => return Err(ConsensusError::TimerErr("No commit timer".to_string())),
         };
 

--- a/src/utils/timer_config.rs
+++ b/src/utils/timer_config.rs
@@ -25,8 +25,8 @@ impl TimerConfig {
     pub fn get_timeout(&self, event: SMREvent) -> ConsensusResult<Duration> {
         match event.clone() {
             SMREvent::NewRoundInfo { .. } => Ok(self.get_propose_timeout()),
-            SMREvent::PrevoteVote(_hash) => Ok(self.get_prevote_timeout()),
-            SMREvent::PrecommitVote(_hash) => Ok(self.get_precommit_timeout()),
+            SMREvent::PrevoteVote { .. } => Ok(self.get_prevote_timeout()),
+            SMREvent::PrecommitVote { .. } => Ok(self.get_precommit_timeout()),
             _ => Err(ConsensusError::TimerErr("No commit timer".to_string())),
         }
     }


### PR DESCRIPTION
This PR does:
* SMR event and trigger add epoch ID and round fields to filter out outdated Triggers touch off by the timer.
* change tokio spawn into runtime spawn
* change the argument of run function from `mut self` into `&self`
* develop the propose timeout coef
* fix a bug that state does not update start time while handling rich status
* fix a bug that state does not cache the hash with the epoch when is a leader